### PR TITLE
Adjust `sideEffects` on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "jsdelivr": "dist/vue-color-kit.global.js",
   "module": "dist/vue-color-kit.esm-bundler.js",
   "types": "dist/vue-color-kit.d.ts",
-  "sideEffects": false,
+  "sideEffects": [".css"],
   "author": "Anish George <anishgeorge2690@gmail.com>",
   "scripts": {
     "dev": "vite serve",


### PR DESCRIPTION
`"sideEffects": false` is causing that current webpack production builds gets the css stripped from the dist package.
This prevent importing the `.css` like you state in the readme, because webpack is treating the `.css` like a `sideEffect`.
Removing the line completly solves the issue, because no file is treated as side effect.

Replacing with this line would tell webpack that the package `.css`is not a side effect that need to be striped on build.
```json
"sideEffects": [".css"]
```

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
<!-- Tip: publish the PR and check the checkboxes by simply clicking on them -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
