### PR TITLE
Added option to pass width as a 'width' prop and some default-colors style fix.

### DIFF
--- a/src/color/ColorPicker.vue
+++ b/src/color/ColorPicker.vue
@@ -126,7 +126,7 @@ export default defineComponent({
     },
     width: {
       type: Number,
-      default: 200,
+      default: 198,
     },
   },
   data() {
@@ -149,7 +149,9 @@ export default defineComponent({
       return this.theme === 'light'
     },
     hueHeight(): number {
-      return this.width * 0.8
+      //making hueHeight such that overall width equal to passed width
+      //20 is the sum of left and right padding of Color Picker
+      return this.width - ((this.hueWidth + 8) * 2 + 20)
     },
     totalWidth(): number {
       return this.hueHeight + (this.hueWidth + 8) * 2

--- a/src/color/ColorPicker.vue
+++ b/src/color/ColorPicker.vue
@@ -124,11 +124,14 @@ export default defineComponent({
       type: String,
       default: 'vue-colorpicker-history',
     },
+    width: {
+      type: Number,
+      default: 200,
+    },
   },
   data() {
     return {
       hueWidth: 15,
-      hueHeight: 152,
       previewHeight: 30,
       modelRgba: '',
       modelHex: '',
@@ -144,6 +147,9 @@ export default defineComponent({
   computed: {
     isLightTheme(): boolean {
       return this.theme === 'light'
+    },
+    hueHeight(): number {
+      return this.width * 0.8
     },
     totalWidth(): number {
       return this.hueHeight + (this.hueWidth + 8) * 2

--- a/src/color/Colors.vue
+++ b/src/color/Colors.vue
@@ -96,7 +96,10 @@ export default defineComponent({
 <style lang="scss">
 .colors {
   padding: 0;
-  margin: 0;
+  margin: 0.5rem 0 0 0;
+  display: flex;
+  gap: 0.44rem;
+  flex-wrap: wrap;
   &.history {
     margin-top: 10px;
     border-top: 1px solid #2e333a;
@@ -105,7 +108,6 @@ export default defineComponent({
     position: relative;
     width: 16px;
     height: 16px;
-    margin: 10px 0 0 10px;
     border-radius: 3px;
     box-sizing: border-box;
     vertical-align: top;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#Pull-Request
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->
<!-- Tip: publish the PR and check the checkboxes by simply clicking on them -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [x] Added option to pass width show that user can change the width of color picker current 198px width seems to be a bit small. 

**Other information:**
I was not able to run tests using `yarn test` getting an error. Image attached.
<img width="1087" alt="Screenshot 2021-11-05 at 5 34 08 PM" src="https://user-images.githubusercontent.com/21134455/140507707-81863372-4b71-4685-830b-576f44ba18b0.png">

